### PR TITLE
Fixed benchmark instability

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -66,7 +66,7 @@ func (bp *BytePipe) Write(b []byte) int {
 		return len(b)
 	}
 	if (w == bp.cap && r == 0) || w == r-1 {
-		// no space eft until reader reads something
+		// no space left until reader reads something
 		bp.wc.L.Lock()
 		if r == atomic.LoadUint32(&bp.r) {
 			bp.wc.Wait()

--- a/buffer.go
+++ b/buffer.go
@@ -8,15 +8,17 @@ import (
 // BytePipe is a high performance single reader/single writer
 // threadsafe pipe to shove bytes through.
 type BytePipe struct {
-	buf []byte // Internal buffer
-	cap uint32 // capacity of the buffer
-	s   uint32 // s==state 1==alive 0==closed
+	wbuf []byte // Internal buffer
+	wi   uint32 // Write index
 
-	r  uint32     // Read index
-	rc *sync.Cond // ReadCondition -- used when reader needs to
+	s       uint32 // s==state 1==alive 0==closed
+	cap     uint32 // capacity of the buffer
+	written uint32 // Bytes written
 
-	w  uint32     // Write index
-	wc *sync.Cond // WriteCondition -- used when writer has no more room
+	rbuf []byte // Internal buffer
+	ri   uint32 // read index
+
+	wrCond *sync.Cond
 }
 
 // NewBytePipe creates a new byte pipe with max buffer size.
@@ -25,26 +27,22 @@ func NewBytePipe(cap uint32) *BytePipe {
 	if cap == 0 {
 		cap = 32768 // 32kb of room for buffering.
 	}
+	buf := make([]byte, cap)
 	return &BytePipe{
-		buf: make([]byte, cap),
-		s:   1,
-		r:   0,
-		w:   0,
-		rc:  sync.NewCond(&sync.Mutex{}),
-		wc:  sync.NewCond(&sync.Mutex{}),
-		cap: cap,
+		rbuf:    buf,
+		wbuf:    buf,
+		s:       1,
+		written: 0,
+		wi:      0,
+		ri:      0,
+		cap:     cap,
+		wrCond:  sync.NewCond(&sync.Mutex{}),
 	}
 }
 
 // Len returns the number of unread bytes in the buffer.
 func (bp *BytePipe) Len() int {
-	r := atomic.LoadUint32(&bp.r)
-	w := atomic.LoadUint32(&bp.w)
-	if r <= w {
-		return int(w - r)
-	}
-
-	return int((bp.cap - r) + (r - w))
+	return int(atomic.LoadUint32(&bp.written))
 }
 
 // Write will copy bytes from b into the pipe.
@@ -54,44 +52,69 @@ func (bp *BytePipe) Write(b []byte) int {
 	if atomic.LoadUint32(&bp.s) == 0 {
 		return 0
 	}
-	r := atomic.LoadUint32(&bp.r)
-	w := atomic.LoadUint32(&bp.w)
+	wr := atomic.LoadUint32(&bp.written)
 	l := uint32(len(b))
 
-	if (w >= r && w+l <= bp.cap) || (r > w && r-w > l) {
-		// more than enough space to write entire thing into it.
-		copy(bp.buf[w:], b)
-		atomic.StoreUint32(&bp.w, w+l)
-		bp.rc.Signal()
-		return len(b)
-	}
-	if (w == bp.cap && r == 0) || w == r-1 {
-		// no space left until reader reads something
-		bp.wc.L.Lock()
-		if r == atomic.LoadUint32(&bp.r) {
-			bp.wc.Wait()
+	// fmt.Printf("WRITE: wants to write %d bytes starting at wi:%d.\n", l, wi)
+	if wr == bp.cap {
+		// fmt.Printf("WRITE: buffer full, wait for read.\n")
+		// wait
+		bp.wrCond.L.Lock()
+		for bp.written == bp.cap {
+			bp.wrCond.Wait()
 		}
-		bp.wc.L.Unlock()
-		return bp.Write(b)
+		wr = bp.written
+		bp.wrCond.L.Unlock()
+		if atomic.LoadUint32(&bp.s) == 0 {
+			return 0
+		}
 	}
-	if w < r {
-		// not enough space! write what we can now, and then call write again to wait.
-		bidx := r - w - 1 // cant overwrite that last byte!
-		copy(bp.buf[w:], b[:bidx])
-		atomic.StoreUint32(&bp.w, r-1)
-		bp.rc.Signal()
-		return bp.Write(b[bidx:]) // Now write the rest
+
+	// Now have SOME space
+	if wr+l > bp.cap {
+		l = bp.cap - wr
+		// fmt.Printf("WRITE: wr: %d, l: %d\n", wr, l)
+		// fmt.Printf("WRITE: not enough space to complete write, cut down to %d.\n", l)
 	}
-	// this means we dont have enought space at the end, write and try again.
-	bidx := bp.cap - w
-	copy(bp.buf[w:], b[:bidx])
-	if r == 0 {
-		atomic.StoreUint32(&bp.w, bp.cap)
-	} else {
-		atomic.StoreUint32(&bp.w, 0)
+	// Now we know how much we CAN write
+	var idx uint32
+	// Check if what we have fits in one write
+
+	// Start writing from start if we are at end.
+	if bp.wi == bp.cap {
+		bp.wi = 0
 	}
-	bp.rc.Signal()
-	return bp.Write(b[bidx:]) // Now write the rest
+	if bp.wi+l > bp.cap {
+		// fmt.Printf("WRITE: write hit cap, rolling over to 0 idx.\n")
+		// Can't fit everything at the end.
+		idx = bp.cap - bp.wi
+		copy(bp.wbuf[bp.wi:], b[:idx])
+		// fmt.Printf("WRITE: buffer state: %v\n", bp.wbuf)
+		// fmt.Printf("WRITE: writing %d bytes start from %d.\n", idx, wi)
+		l -= idx
+		bp.wi = 0
+	}
+
+	// write what what have
+	copy(bp.wbuf[bp.wi:], b[idx:idx+l])
+	// Store new write index
+	// Update total written bytes
+	bp.wi += l
+	total := l + idx
+
+	bp.wrCond.L.Lock()
+	bp.written += total
+	bp.wrCond.Broadcast()
+	bp.wrCond.L.Unlock()
+
+	// If we wrote everything, exit here
+	if total == uint32(len(b)) {
+		// fmt.Printf("WRITE: wrote all %d bytes of request: %d.\n", total, int(l))
+		return int(total)
+	}
+
+	// fmt.Printf("WRITE: recursing to write %d to %d.\n", total, len(b))
+	return int(total) + bp.Write(b[total:]) // Now write the rest
 }
 
 // Read will copy bytes from pipe into provided buffer.
@@ -102,45 +125,66 @@ func (bp *BytePipe) Read(b []byte) int {
 	if atomic.LoadUint32(&bp.s) == 0 {
 		return 0
 	}
-
-	r := atomic.LoadUint32(&bp.r)
-	w := atomic.LoadUint32(&bp.w)
+	wr := atomic.LoadUint32(&bp.written)
 	l := uint32(len(b))
 
-	if (r > w && r+l < bp.cap) || (r < w && w-r > l) {
-		// Have more bytes ready than len(b), just do it
-		copy(b, bp.buf[r:r+l])
-		atomic.StoreUint32(&bp.r, r+l)
-		bp.wc.Signal()
-		return int(l)
-	}
-	if r > w {
-		// we have more bytes, but need to wrap around to finish reading.
-		copy(b, bp.buf[r:bp.cap])
-		atomic.StoreUint32(&bp.r, 0)
-		bp.wc.Signal()
-		return bp.Read(b[bp.cap-r:]) + int(bp.cap-r)
-	}
-	if r == w {
+	// If written == 0 there is nothing in pipe
+	if wr == 0 {
+		// fmt.Printf("READ: nothing to read, waiting.\n")
 		// We dont have anything to read, wait for now
-		bp.rc.L.Lock()
-		if w == atomic.LoadUint32(&bp.w) {
-			bp.rc.Wait()
+		bp.wrCond.L.Lock()
+		for bp.written == 0 {
+			bp.wrCond.Wait()
 		}
-		bp.rc.L.Unlock()
-		return bp.Read(b)
+		wr = bp.written
+		bp.wrCond.L.Unlock()
+		if atomic.LoadUint32(&bp.s) == 0 {
+			return 0
+		}
+		wr = atomic.LoadUint32(&bp.written)
 	}
-	// Finally, this means we have less bytes available than size of b, copy what we have.
-	copy(b, bp.buf[r:w])
-	atomic.StoreUint32(&bp.r, w)
-	bp.wc.Signal()
-	return int(w - r)
+
+	// We for sure have at least 1 byte
+	// Set L to how much we can read
+	if wr < l {
+		// fmt.Printf("READ: only %d bytes available (wanted %d)\n", wr, l)
+		l = wr
+	}
+
+	if bp.ri == bp.cap {
+		bp.ri = 0
+	}
+
+	var total uint32 // how many bytes did we read?
+	// Check if what we have fits in one read
+	if bp.ri+l > bp.cap {
+		total = bp.cap - bp.ri
+		copy(b, bp.rbuf[bp.ri:bp.ri+total])
+		// fmt.Printf("READ:  buffer state: %v\n", bp.rbuf)
+		l -= total
+		bp.ri = 0
+		// fmt.Printf("READ: read %d bytes from end of buffer. left to read l: %d\n", idx, l)
+	}
+
+	// fmt.Printf("READ: Reading %d bytes.\n", l)
+	// now read how much is left to read
+	copy(b[total:], bp.rbuf[bp.ri:bp.ri+l])
+	// fmt.Printf("READ:  buffer state: %v\n", bp.rbuf)
+	bp.ri += l
+	total += l
+	// fmt.Printf("READ: total now: %d\n", total)
+	// Update total written bytes
+	bp.wrCond.L.Lock()
+	bp.written -= total
+	bp.wrCond.Broadcast()
+	bp.wrCond.L.Unlock()
+	// fmt.Printf("READ: bp.Written now at: %d\n", atomic.LoadUint32(&bp.written))
+	// fmt.Printf("READ: Written decremented by %d. returning %d bytes read.\n", total, total)
+	return int(total) // Now return how much we read
 }
 
 // Close will shutdown the pipe and signal any waiting goroutines.
 func (bp *BytePipe) Close() {
 	atomic.StoreUint32(&bp.s, 0)
-
-	bp.wc.Signal()
-	bp.rc.Signal()
+	atomic.StoreUint32(&bp.written, 0)
 }

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -109,6 +109,7 @@ func BenchmarkChannel1024(b *testing.B) {
 		<-pipe
 	}
 	b.StopTimer()
+	close(pipe)
 }
 
 func BenchmarkBytePipe1024(b *testing.B) {
@@ -118,11 +119,14 @@ func BenchmarkBytePipe1024(b *testing.B) {
 	b.ResetTimer()
 	go func(n int) {
 		for i := 0; i < b.N; i++ {
-			pipe.Write(inbuf)
+			if pipe.Write(inbuf) == 0 {
+				break
+			}
 		}
 	}(b.N)
 	for i := 0; i < b.N; i++ {
 		pipe.Read(buf)
 	}
 	b.StopTimer()
+	pipe.Close()
 }

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -1,51 +1,96 @@
 package bytepipe
 
 import (
+	"fmt"
 	"log"
 	"testing"
+	"time"
 )
 
 func TestBytePipe(t *testing.T) {
 	pipe := NewBytePipe(20)
 	go func() {
-		pipe.Write(make([]byte, 5))
-		pipe.Write(make([]byte, 6))
-		pipe.Write(make([]byte, 7))
-		pipe.Write(make([]byte, 8))
+		wtot := 0
+		wtot += pipe.Write([]byte{1, 2, 3, 4, 5})
+		wtot += pipe.Write([]byte{6, 7, 8, 9, 10, 11})
+		wtot += pipe.Write([]byte{12, 13, 14, 15, 16, 17, 18})
+		wtot += pipe.Write([]byte{19, 20, 21, 22, 23, 24, 25, 26})
+		log.Printf("TestBytePipe Wrote: %d bytes\n", wtot)
+		if wtot != 26 {
+			t.FailNow()
+		}
 	}()
-
-	buf := make([]byte, 10)
+	time.Sleep(time.Second)
+	buf := make([]byte, 15)
 	n := pipe.Read(buf)
+	counter := 0
+	fmt.Printf("Read %d bytes\n", n)
+	for i := 0; i < n; i++ {
+		if int(buf[i]) != (i + counter + 1) {
+			log.Printf("Byte %d value %d value was incorrect, expected: %d", i+counter, buf[i], i+counter+1)
+		}
+	}
+	counter = n
 	n2 := pipe.Read(buf)
-	if n+n2 == 15 {
+	fmt.Printf("Read %d bytes\n", n2)
+	for i := 0; i < n2; i++ {
+		if int(buf[i]) != (i + counter + 1) {
+			log.Printf("Byte %d value %d value was incorrect, expected: %d", i+counter, buf[i], i+counter+1)
+		}
+	}
+	counter += n2
+	if n+n2 == 26 {
 		// This means that we read all bytes in two reads.
 		return
 	}
 	n = pipe.Read(buf)
-	// This means some writes were still occuring when we
+	// This means some writes were still occuring when we were reading
 	if n == 0 {
 		//
 		t.FailNow()
 	}
+	for i := 0; i < n; i++ {
+		if int(buf[i]) != (i + counter + 1) {
+			log.Printf("Byte %d value %d value was incorrect, expected: %d", i+counter, buf[i], i+counter+1)
+		}
+	}
 }
 
 func TestBytePipeLargeMessage(t *testing.T) {
+	// Write more bytes to buffer than fit
+	// Try reading while write is still occuring
 	numBytes := 50
-	var pipeCap uint32 = 10
-	buffer := 20
+	var pipeCap uint32 = 20
+	buffer := 10
 
 	pipe := NewBytePipe(pipeCap)
 	go func(nb int) {
 		// Write in them bytes!
-		pipe.Write(make([]byte, nb))
+		a := make([]byte, nb)
+		for i := 0; i < nb; i++ {
+			a[i] = byte(i + 1)
+		}
+		wrote := pipe.Write(a)
+		log.Printf("TestBytePipeLarge Wrote num bytes: %d\n", wrote)
+		if wrote != nb {
+			t.FailNow()
+		}
 	}(numBytes)
 
+	time.Sleep(time.Second)
 	buf := make([]byte, buffer)
 	total := 0
 	for total < numBytes {
-		total += pipe.Read(buf)
+		n := pipe.Read(buf)
+		total += n
+		log.Printf("Read %d bytes, total: %d\n", n, total)
 	}
+
 	log.Printf("Read %d bytes using a %d buffer", total, buffer)
+	if pipe.Len() != 0 {
+		log.Printf("Bytes left after reading everything: %d", pipe.Len())
+		t.FailNow()
+	}
 }
 
 // func TestOutput(t *testing.T) {
@@ -109,7 +154,6 @@ func BenchmarkChannel1024(b *testing.B) {
 		<-pipe
 	}
 	b.StopTimer()
-	close(pipe)
 }
 
 func BenchmarkBytePipe1024(b *testing.B) {
@@ -118,15 +162,16 @@ func BenchmarkBytePipe1024(b *testing.B) {
 	inbuf := make([]byte, 1024)
 	b.ResetTimer()
 	go func(n int) {
-		for i := 0; i < b.N; i++ {
+		for i := 0; i < n; i++ {
 			if pipe.Write(inbuf) == 0 {
 				break
 			}
 		}
 	}(b.N)
 	for i := 0; i < b.N; i++ {
-		pipe.Read(buf)
+		if pipe.Read(buf) == 0 {
+			break
+		}
 	}
 	b.StopTimer()
-	pipe.Close()
 }


### PR DESCRIPTION
Fixed instability caused by benchmarks that spawn goroutines and having them block on a write. 

Rewrote to contains a 'written' value. Then the reader/writer only synchronize on how much data exists which removes race conditions.
